### PR TITLE
LittleFS driver on Miosix working and tested

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,11 +1,67 @@
 
-#include <cstdio>
 #include "miosix.h"
+#include <cstdio>
+#include <dirent.h>
+#include <errno.h>
 
 using namespace std;
 using namespace miosix;
 
-int main()
-{
-    //iprintf("Hello world, write your application here\n");
+void tryReadFile() {
+  iprintf("Trying to read /sd/test.txt\n");
+  // Try to read the file
+  FILE *fp = fopen("/sd/test.txt", "r");
+  // Check file is open
+  if (fp != NULL) {
+    char buf[100];
+    fgets(buf, 100, fp);
+    iprintf("File content: %s\n", buf);
+    fclose(fp);
+  } else {
+    perror("Error opening /sd/test.txt in readmode");
+  }
+}
+
+int main() {
+  iprintf("Main start\n");
+
+  // Try to opena non-existing directory
+
+  DIR *dir0 = opendir("/fcguyidsa");
+  if (dir0 == NULL) {
+    perror("Couldn't open /fcguyidsa directory, AS EXPECTED");
+  } else {
+    iprintf("Opened /fcguyidsa directory???????");
+    closedir(dir0);
+  }
+
+  // List all the files in the root directory
+  DIR *dir = opendir("/sd");
+  if (dir == NULL) {
+    perror("Error opening /sd directory");
+    return -1;
+  }
+  struct dirent *ent;
+  iprintf("Files in /sd:\n");
+  while ((ent = readdir(dir)) != NULL) {
+    iprintf("\tFound file: %s\n", ent->d_name);
+  }
+  closedir(dir);
+
+  tryReadFile();
+
+  // Open a file and write something
+  iprintf("Writing to /sd/test.txt\n");
+  FILE *fp = fopen("/sd/test.txt", "w");
+  // Check file is open
+  if (fp == NULL) {
+    perror("Error opening /sd/test.txt in writemode");
+    return -1;
+  }
+  fprintf(fp, "Hello world!\n");
+  fclose(fp);
+
+  tryReadFile();
+
+  iprintf("Main end\n");
 }

--- a/miosix/filesystem/file_access.cpp
+++ b/miosix/filesystem/file_access.cpp
@@ -707,7 +707,7 @@ intrusive_ref_ptr<FilesystemBase> rootFs
                    intrusive_ref_ptr<DevFs> devfs
 #endif
 ) {
-  bootlog("Mounting % as /sd ... ", typeid(T).name());
+  bootlog("Mounting %s as /sd ... ", typeid(T).name());
   intrusive_ref_ptr<FileBase> disk;
   FilesystemManager& fsm=FilesystemManager::instance();
 #ifdef WITH_DEVFS

--- a/miosix/filesystem/littlefs/bd/lfs_rambd.c
+++ b/miosix/filesystem/littlefs/bd/lfs_rambd.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2017, Arm Limited. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#include "bd/lfs_rambd.h"
+#include "lfs_rambd.h"
 
 int lfs_rambd_create(const struct lfs_config *cfg,
         const struct lfs_rambd_config *bdcfg) {

--- a/miosix/filesystem/littlefs/bd/lfs_rambd.h
+++ b/miosix/filesystem/littlefs/bd/lfs_rambd.h
@@ -8,8 +8,8 @@
 #ifndef LFS_RAMBD_H
 #define LFS_RAMBD_H
 
-#include "lfs.h"
-#include "lfs_util.h"
+#include "../lfs.h"
+#include "../lfs_util.h"
 
 #ifdef __cplusplus
 extern "C"

--- a/miosix/filesystem/littlefs/lfs_miosix.cpp
+++ b/miosix/filesystem/littlefs/lfs_miosix.cpp
@@ -1,8 +1,15 @@
 #include "lfs_miosix.h"
 #include "filesystem/stringpart.h"
 #include "kernel/logging.h"
-
 #include <fcntl.h>
+
+// TODO: Remove this
+#define LFS_MIOSIX_IN_RAM
+
+#ifdef LFS_MIOSIX_IN_RAM
+#include "bd/lfs_rambd.c"
+#include "bd/lfs_rambd.h"
+#endif
 
 // configuration of the filesystem is provided by this struct
 const struct lfs_config LITTLEFS_CONFIG = {
@@ -23,9 +30,36 @@ const struct lfs_config LITTLEFS_CONFIG = {
     .lookahead_size = 16,
 };
 
+struct lfs_rambd_config LFS_FILE_CONFIG = {
+    .read_size = 16,
+    .prog_size = 16,
+    .erase_size = 4096,
+    .erase_count = 128,
+};
+
 miosix::LittleFS::LittleFS(intrusive_ref_ptr<FileBase> disk) {
+  int err;
   drv = disk;
-  struct lfs_config config = LITTLEFS_CONFIG;
+  config = LITTLEFS_CONFIG;
+#ifdef LFS_MIOSIX_IN_RAM
+  config.read = lfs_rambd_read;
+  config.prog = lfs_rambd_prog;
+  config.erase = lfs_rambd_erase;
+  config.sync = lfs_rambd_sync;
+  config.context = &this->rambd;
+  err = lfs_rambd_create(&config, &LFS_FILE_CONFIG);
+  if (err) {
+    bootlog("Error creating filebd: %d\n", err);
+    mountError = convert_lfs_error_into_posix(err);
+    return;
+  }
+  err = lfs_format(&lfs, &config);
+  if (err) {
+    bootlog("Error formatting LittleFS: %d\n", err);
+    mountError = convert_lfs_error_into_posix(err);
+    return;
+  }
+#else
   // Put the drive instance into the config context. Note that a raw pointer is
   // passed, but the object is kept alive by the intrusive_ref_ptr in the drv
   // member variable. Hence, the object is deleted when the LittleFS object is
@@ -35,8 +69,8 @@ miosix::LittleFS::LittleFS(intrusive_ref_ptr<FileBase> disk) {
   config.prog = miosix_block_device_prog;
   config.erase = miosix_block_device_erase;
   config.sync = miosix_block_device_sync;
-
-  int err = lfs_mount(&lfs, &config);
+#endif
+  err = lfs_mount(&lfs, &config);
   mountError = convert_lfs_error_into_posix(err);
 }
 
@@ -45,31 +79,46 @@ int miosix::LittleFS::open(intrusive_ref_ptr<FileBase> &file, StringPart &name,
   if (mountFailed())
     return -ENOENT;
 
-  // Convert MIOSIX flags to LITTLEFS flags
-  int lfsFlags = 0;
+  // Check if we are trying to open a file or a directory
+  if (flags & _FDIRECTORY) {
+    return open_directory(file, name, flags, mode);
+  } else {
+    return open_file(file, name, flags, mode);
+  }
+}
 
-  if (flags & O_RDONLY)
-    lfsFlags |= LFS_O_RDONLY;
-  if (flags & O_WRONLY)
-    lfsFlags |= LFS_O_WRONLY;
-  if (flags & O_APPEND)
-    lfsFlags |= LFS_O_APPEND;
-  if (flags & O_CREAT)
-    lfsFlags |= LFS_O_CREAT;
-  if (flags & O_TRUNC)
-    lfsFlags |= LFS_O_TRUNC;
-  if (flags & O_EXCL)
-    lfsFlags |= LFS_O_EXCL;
+int miosix::LittleFS::open_directory(intrusive_ref_ptr<FileBase> &directory,
+                                     StringPart &name, int flags, int mode) {
+  directory = intrusive_ref_ptr<LittleFSDirectory>(
+      new LittleFSDirectory(intrusive_ref_ptr<LittleFS>(this)));
 
-  struct lfs_file littlefsFile;
-  int err = lfs_file_open(&lfs, &littlefsFile, name.c_str(), flags);
-
+  int err = lfs_dir_open(
+      &lfs,
+      static_cast<LittleFSDirectory *>(directory.get())->getDirReference(),
+      name.c_str());
   if (err) {
+    directory.reset();
     return convert_lfs_error_into_posix(err);
   }
 
-  file = intrusive_ref_ptr<LittleFSFile>(new LittleFSFile(
-      intrusive_ref_ptr<LittleFS>(this), littlefsFile, flags & O_SYNC));
+  static_cast<LittleFSDirectory *>(directory.get())->setAsOpen();
+  return 0;
+}
+
+int miosix::LittleFS::open_file(intrusive_ref_ptr<FileBase> &file,
+                                StringPart &name, int flags, int mode) {
+  file = intrusive_ref_ptr<LittleFSFile>(
+      new LittleFSFile(intrusive_ref_ptr<LittleFS>(this), flags & O_SYNC));
+
+  int err = lfs_file_open(
+      &lfs, static_cast<LittleFSFile *>(file.get())->getFileReference(),
+      name.c_str(), convert_posix_open_to_lfs_flags(flags));
+  if (err) {
+    file.reset();
+    return convert_lfs_error_into_posix(err);
+  }
+  static_cast<LittleFSFile *>(file.get())->setAsOpen();
+
   return 0;
 }
 
@@ -141,6 +190,7 @@ int miosix::LittleFS::rmdir(StringPart &name) {
 }
 
 miosix::LittleFS::~LittleFS() {
+  lfs_rambd_destroy(&config);
   if (mountFailed())
     return;
   int err = lfs_unmount(&lfs);
@@ -163,7 +213,26 @@ int miosix::convert_lfs_error_into_posix(int lfs_err) {
   return lfs_err;
 }
 
+int miosix::convert_posix_open_to_lfs_flags(int posix_flags) {
+  int lfsFlags = 0;
+
+  if ((posix_flags & O_RDONLY) == O_RDONLY)
+    lfsFlags |= LFS_O_RDONLY;
+  if ((posix_flags & O_WRONLY) == O_WRONLY)
+    lfsFlags |= LFS_O_WRONLY;
+  if ((posix_flags & O_APPEND) == O_APPEND)
+    lfsFlags |= LFS_O_APPEND;
+  if ((posix_flags & O_CREAT) == O_CREAT)
+    lfsFlags |= LFS_O_CREAT;
+  if ((posix_flags & O_TRUNC) == O_TRUNC)
+    lfsFlags |= LFS_O_TRUNC;
+  if ((posix_flags & O_EXCL) == O_EXCL)
+    lfsFlags |= LFS_O_EXCL;
+  return lfsFlags;
+}
+
 int miosix::LittleFSFile::read(void *buf, size_t count) {
+  assert(isOpen);
   // Get the LittleFS driver istance using getParent()
   LittleFS *lfs_driver = static_cast<LittleFS *>(getParent().get());
   auto readSize = lfs_file_read(lfs_driver->getLfs(), &file, buf, count);
@@ -171,6 +240,7 @@ int miosix::LittleFSFile::read(void *buf, size_t count) {
 }
 
 int miosix::LittleFSFile::write(const void *buf, size_t count) {
+  assert(isOpen);
   LittleFS *lfs_driver = static_cast<LittleFS *>(getParent().get());
   auto writeSize = lfs_file_write(lfs_driver->getLfs(), &file, buf, count);
   if (forceSync)
@@ -179,13 +249,56 @@ int miosix::LittleFSFile::write(const void *buf, size_t count) {
 }
 
 off_t miosix::LittleFSFile::lseek(off_t pos, int whence) {
+  assert(isOpen);
   // TODO: Implement using lfs APIs
   return -ENOENT;
 }
 
 int miosix::LittleFSFile::fstat(struct stat *pstat) const {
+  assert(isOpen);
   // TODO: Implement using lfs APIs
   return -ENOENT;
+}
+
+int miosix::LittleFSDirectory::getdents(void *dp, int len) {
+  if (len < minimumBufferSize) {
+    return -EINVAL;
+  }
+
+  LittleFS *lfs_driver = static_cast<LittleFS *>(getParent().get());
+  lfs_info dirInfo;
+
+  char *bufferBegin = static_cast<char *>(dp);
+  char *bufferEnd = bufferBegin + len;
+  char *bufferCurPos = bufferBegin; // Current position in the buffer
+
+  int dirReadResult;
+  while ((dirReadResult = lfs_dir_read(lfs_driver->getLfs(), &dir, &dirInfo)) >=
+         0) {
+    if (dirReadResult == 0) {
+      // No more entries
+      if (addTerminatingEntry(&bufferCurPos, bufferEnd) < 0) {
+        // The terminating entry does not fit in the buffer
+        return -ENOMEM;
+      }
+      break;
+    }
+
+    // TODO: Add correct inode number instead of `-10`
+    if (addEntry(&bufferCurPos, bufferEnd, -10,
+                 dirInfo.type == LFS_TYPE_REG ? DT_REG : DT_DIR,
+                 StringPart(dirInfo.name)) < 0) {
+      // The entry does not fit in the buffer
+      return -ENOMEM;
+    }
+  };
+
+  // We did not naturally reach the end, but a read error occurred
+  if (dirReadResult < 0) {
+    return convert_lfs_error_into_posix(dirReadResult);
+  }
+
+  return bufferCurPos - bufferBegin;
 }
 
 int miosix::miosix_block_device_read(const lfs_config *c, lfs_block_t block,


### PR DESCRIPTION
Completed actual implementation of the LittleFS driver for Miosix.

This time, compared to d3c2ac56817ed5376f406195eabed9f88bbc5e2a, I actually tested to see if it runs correctly.

I tested by using a ram block device, its implementation comes with LittleFS library.