### PR TITLE
Block device operations: read, prog, erase, sync

### DIFF
--- a/miosix/filesystem/littlefs/lfs_miosix.cpp
+++ b/miosix/filesystem/littlefs/lfs_miosix.cpp
@@ -1,4 +1,5 @@
 #include "lfs_miosix.h"
+#include "filesystem/ioctl.h"
 #include "filesystem/stringpart.h"
 #include "kernel/logging.h"
 #include <fcntl.h>
@@ -19,15 +20,13 @@ const struct lfs_config LITTLEFS_CONFIG = {
     .erase = nullptr,
     .sync = nullptr,
 
-    // TODO: Check this are OK for Miosix
     // block device configuration
-    .read_size = 16,
-    .prog_size = 16,
+    .read_size = 512,
+    .prog_size = 512,
     .block_size = 512,
-    .block_count = 128,
     .block_cycles = 500,
-    .cache_size = 16,
-    .lookahead_size = 16,
+    .cache_size = 512,
+    .lookahead_size = 512,
 };
 
 struct lfs_rambd_config LFS_FILE_CONFIG = {
@@ -309,11 +308,14 @@ int miosix::miosix_block_device_read(const lfs_config *c, lfs_block_t block,
                                      lfs_size_t size) {
   FileBase *drv = static_cast<FileBase *>(c->context);
 
-  if (drv->lseek(static_cast<off_t>((block)*c->block_size) + off, SEEK_SET) < 0)
+
+  if (drv->lseek(static_cast<off_t>(c->block_size * block + off), SEEK_SET) <
+      0) {
     return LFS_ERR_IO;
-  if (drv->read(buffer, size * c->block_size) !=
-      static_cast<ssize_t>(size) * c->block_size)
+  }
+  if (drv->read(buffer, size) != static_cast<ssize_t>(size)) {
     return LFS_ERR_IO;
+  }
   return LFS_ERR_OK;
 }
 
@@ -322,11 +324,13 @@ int miosix::miosix_block_device_prog(const lfs_config *c, lfs_block_t block,
                                      lfs_size_t size) {
   FileBase *drv = static_cast<FileBase *>(c->context);
 
-  if (drv->lseek(static_cast<off_t>((block)*c->block_size) + off, SEEK_SET) < 0)
+  if (drv->lseek(static_cast<off_t>(c->block_size * block + off), SEEK_SET) <
+      0) {
     return LFS_ERR_IO;
-  if (drv->write(buffer, size * c->block_size) !=
-      static_cast<ssize_t>(size) * c->block_size)
+  }
+  if (drv->write(buffer, size) != static_cast<ssize_t>(size)) {
     return LFS_ERR_IO;
+  }
   return LFS_ERR_OK;
 }
 
@@ -336,15 +340,20 @@ int miosix::miosix_block_device_erase(const lfs_config *c, lfs_block_t block) {
   std::unique_ptr<int[]> buffer(new int[c->block_size]);
   memset(buffer.get(), 0, c->block_size);
 
-  if (drv->lseek(static_cast<off_t>((block)*c->block_size), SEEK_SET) < 0)
+  if (drv->lseek(static_cast<off_t>((block)*c->block_size), SEEK_SET) < 0) {
     return LFS_ERR_IO;
-  if (drv->write(buffer.get(), c->block_size) != c->block_size)
+  }
+  if (drv->write(buffer.get(), c->block_size) != c->block_size) {
     return LFS_ERR_IO;
+  }
   return LFS_ERR_OK;
 }
 
 int miosix::miosix_block_device_sync(const lfs_config *c) {
-  // TODO: Implement using MIOSIX APIs
   FileBase *drv = static_cast<FileBase *>(c->context);
-  return -ENOENT;
+
+  if (drv->ioctl(IOCTL_SYNC, nullptr) != 0) {
+    return LFS_ERR_IO;
+  }
+  return -LFS_ERR_OK;
 }

--- a/miosix/filesystem/littlefs/lfs_miosix.cpp
+++ b/miosix/filesystem/littlefs/lfs_miosix.cpp
@@ -2,6 +2,7 @@
 #include "filesystem/stringpart.h"
 #include "kernel/logging.h"
 #include <fcntl.h>
+#include <memory>
 
 // TODO: Remove this
 #define LFS_MIOSIX_IN_RAM
@@ -307,27 +308,36 @@ int miosix::LittleFSDirectory::getdents(void *dp, int len) {
 int miosix::miosix_block_device_read(const lfs_config *c, lfs_block_t block,
                                      lfs_off_t off, void *buffer,
                                      lfs_size_t size) {
-  // TODO: Implement using MIOSIX APIs
-  //FileBase *drv = static_cast<FileBase *>(c->context);
-  return -ENOENT;
+  FileBase *drv = static_cast<FileBase *>(c->context);
+
+  if(drv->lseek(static_cast<off_t>((block)*c->block_size) + off,SEEK_SET)<0) return LFS_ERR_IO;
+    if(drv->read(buffer,size*c->block_size)!=static_cast<ssize_t>(size)*c->block_size) return LFS_ERR_IO;
+    return LFS_ERR_OK;
 }
 
 int miosix::miosix_block_device_prog(const lfs_config *c, lfs_block_t block,
                                      lfs_off_t off, const void *buffer,
                                      lfs_size_t size) {
-  // TODO: Implement using MIOSIX APIs
-  //FileBase *drv = static_cast<FileBase *>(c->context);
-  return -ENOENT;
+  FileBase *drv = static_cast<FileBase *>(c->context);
+
+  if(drv->lseek(static_cast<off_t>((block)*c->block_size) + off,SEEK_SET)<0) return LFS_ERR_IO;
+    if(drv->write(buffer,size*c->block_size)!=static_cast<ssize_t>(size)*c->block_size) return LFS_ERR_IO;
+    return LFS_ERR_OK;
 }
 
 int miosix::miosix_block_device_erase(const lfs_config *c, lfs_block_t block) {
-  // TODO: Implement using MIOSIX APIs
-  //FileBase *drv = static_cast<FileBase *>(c->context);
-  return -ENOENT;
+  FileBase *drv = static_cast<FileBase *>(c->context);
+
+  std::unique_ptr<int[]> buffer(new int[c->block_size]);
+  memset(buffer.get(), 0, c->block_size);
+
+  if(drv->lseek(static_cast<off_t>((block)*c->block_size),SEEK_SET)<0) return LFS_ERR_IO;
+    if(drv->write(buffer.get(),c->block_size)!=c->block_size) return LFS_ERR_IO;
+    return LFS_ERR_OK;
 }
 
 int miosix::miosix_block_device_sync(const lfs_config *c) {
   // TODO: Implement using MIOSIX APIs
-  //FileBase *drv = static_cast<FileBase *>(c->context);
+  FileBase *drv = static_cast<FileBase *>(c->context);
   return -ENOENT;
 }

--- a/miosix/filesystem/littlefs/lfs_miosix.cpp
+++ b/miosix/filesystem/littlefs/lfs_miosix.cpp
@@ -4,11 +4,10 @@
 #include <fcntl.h>
 #include <memory>
 
-// TODO: Remove this
-#define LFS_MIOSIX_IN_RAM
+// Uncomment to enable mounting LFS in ram
+// #define LFS_MIOSIX_IN_RAM
 
 #ifdef LFS_MIOSIX_IN_RAM
-#include "bd/lfs_rambd.c"
 #include "bd/lfs_rambd.h"
 #endif
 
@@ -24,7 +23,7 @@ const struct lfs_config LITTLEFS_CONFIG = {
     // block device configuration
     .read_size = 16,
     .prog_size = 16,
-    .block_size = 4096,
+    .block_size = 512,
     .block_count = 128,
     .block_cycles = 500,
     .cache_size = 16,
@@ -34,7 +33,7 @@ const struct lfs_config LITTLEFS_CONFIG = {
 struct lfs_rambd_config LFS_FILE_CONFIG = {
     .read_size = 16,
     .prog_size = 16,
-    .erase_size = 4096,
+    .erase_size = 512,
     .erase_count = 128,
 };
 
@@ -310,9 +309,12 @@ int miosix::miosix_block_device_read(const lfs_config *c, lfs_block_t block,
                                      lfs_size_t size) {
   FileBase *drv = static_cast<FileBase *>(c->context);
 
-  if(drv->lseek(static_cast<off_t>((block)*c->block_size) + off,SEEK_SET)<0) return LFS_ERR_IO;
-    if(drv->read(buffer,size*c->block_size)!=static_cast<ssize_t>(size)*c->block_size) return LFS_ERR_IO;
-    return LFS_ERR_OK;
+  if (drv->lseek(static_cast<off_t>((block)*c->block_size) + off, SEEK_SET) < 0)
+    return LFS_ERR_IO;
+  if (drv->read(buffer, size * c->block_size) !=
+      static_cast<ssize_t>(size) * c->block_size)
+    return LFS_ERR_IO;
+  return LFS_ERR_OK;
 }
 
 int miosix::miosix_block_device_prog(const lfs_config *c, lfs_block_t block,
@@ -320,9 +322,12 @@ int miosix::miosix_block_device_prog(const lfs_config *c, lfs_block_t block,
                                      lfs_size_t size) {
   FileBase *drv = static_cast<FileBase *>(c->context);
 
-  if(drv->lseek(static_cast<off_t>((block)*c->block_size) + off,SEEK_SET)<0) return LFS_ERR_IO;
-    if(drv->write(buffer,size*c->block_size)!=static_cast<ssize_t>(size)*c->block_size) return LFS_ERR_IO;
-    return LFS_ERR_OK;
+  if (drv->lseek(static_cast<off_t>((block)*c->block_size) + off, SEEK_SET) < 0)
+    return LFS_ERR_IO;
+  if (drv->write(buffer, size * c->block_size) !=
+      static_cast<ssize_t>(size) * c->block_size)
+    return LFS_ERR_IO;
+  return LFS_ERR_OK;
 }
 
 int miosix::miosix_block_device_erase(const lfs_config *c, lfs_block_t block) {
@@ -331,9 +336,11 @@ int miosix::miosix_block_device_erase(const lfs_config *c, lfs_block_t block) {
   std::unique_ptr<int[]> buffer(new int[c->block_size]);
   memset(buffer.get(), 0, c->block_size);
 
-  if(drv->lseek(static_cast<off_t>((block)*c->block_size),SEEK_SET)<0) return LFS_ERR_IO;
-    if(drv->write(buffer.get(),c->block_size)!=c->block_size) return LFS_ERR_IO;
-    return LFS_ERR_OK;
+  if (drv->lseek(static_cast<off_t>((block)*c->block_size), SEEK_SET) < 0)
+    return LFS_ERR_IO;
+  if (drv->write(buffer.get(), c->block_size) != c->block_size)
+    return LFS_ERR_IO;
+  return LFS_ERR_OK;
 }
 
 int miosix::miosix_block_device_sync(const lfs_config *c) {

--- a/miosix/filesystem/littlefs/lfs_miosix.cpp
+++ b/miosix/filesystem/littlefs/lfs_miosix.cpp
@@ -336,17 +336,24 @@ int miosix::miosix_block_device_prog(const lfs_config *c, lfs_block_t block,
 
 int miosix::miosix_block_device_erase(const lfs_config *c, lfs_block_t block) {
   FileBase *drv = static_cast<FileBase *>(c->context);
+  int err = LFS_ERR_OK;
 
-  std::unique_ptr<int[]> buffer(new int[c->block_size]);
-  memset(buffer.get(), 0, c->block_size);
+  int *buffer = new int[c->block_size];
+  memset(buffer, 0, c->block_size);
 
   if (drv->lseek(static_cast<off_t>((block)*c->block_size), SEEK_SET) < 0) {
-    return LFS_ERR_IO;
+    err = LFS_ERR_IO;
+    goto exit;
   }
-  if (drv->write(buffer.get(), c->block_size) != c->block_size) {
-    return LFS_ERR_IO;
+  if (drv->write(buffer, c->block_size) !=
+      static_cast<ssize_t>(c->block_size)) {
+    err = LFS_ERR_IO;
+    goto exit;
   }
-  return LFS_ERR_OK;
+
+exit:
+  delete[] buffer;
+  return err;
 }
 
 int miosix::miosix_block_device_sync(const lfs_config *c) {


### PR DESCRIPTION
Implementation of the operation on the block device (SD):
1. read
2. prog
3. erase

Currently untested.